### PR TITLE
Add icons to IGCSE subjects

### DIFF
--- a/src/components/FileNavigator.jsx
+++ b/src/components/FileNavigator.jsx
@@ -26,6 +26,12 @@ import {
   Trophy,
   Clock,
   AlertTriangle,
+  DollarSign,
+  Languages,
+  Dna,
+  TrendingUp,
+  BookOpen,
+  Monitor,
 } from "lucide-react";
 import {
   getUserCompletedMocks,
@@ -1158,6 +1164,39 @@ export default function FileNavigator({
       );
     }
 
+    // IGCSE Subjects with icons
+    if (keyLower.includes("accounting")) {
+      return (
+        <DollarSign size={16} className="mr-1.5 flex-shrink-0 text-green-500" />
+      );
+    }
+    if (keyLower.includes("bangla")) {
+      return (
+        <Languages size={16} className="mr-1.5 flex-shrink-0 text-orange-400" />
+      );
+    }
+    if (keyLower.includes("biology")) {
+      return (
+        <Dna size={16} className="mr-1.5 flex-shrink-0 text-emerald-400" />
+      );
+    }
+    if (keyLower.includes("economics")) {
+      return (
+        <TrendingUp size={16} className="mr-1.5 flex-shrink-0 text-yellow-400" />
+      );
+    }
+    if (keyLower.includes("english language")) {
+      return (
+        <BookOpen size={16} className="mr-1.5 flex-shrink-0 text-blue-500" />
+      );
+    }
+    if (keyLower === "ict" || keyLower.includes("information")) {
+      return (
+        <Monitor size={16} className="mr-1.5 flex-shrink-0 text-purple-500" />
+      );
+    }
+
+    // Existing subjects
     if (keyLower.includes("chemistry")) {
       return (
         <FlaskConical


### PR DESCRIPTION
Add relevant icons to IGCSE subjects (Accounting, Bangla, Biology, Economics, English Language B, ICT) to improve navigation and visual identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-10f39e97-bdf2-4a42-bb28-916a3170bb68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10f39e97-bdf2-4a42-bb28-916a3170bb68">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

