### PR TITLE
Fix pdf.js viewer for IGCSE subjects

### DIFF
--- a/api/pdf-proxy.js
+++ b/api/pdf-proxy.js
@@ -9,6 +9,7 @@ export default function handler(req, res) {
     "GET, POST, PUT, DELETE, OPTIONS"
   );
   res.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+  res.setHeader("Access-Control-Allow-Credentials", "true");
 
   // Handle preflight requests
   if (req.method === "OPTIONS") {
@@ -25,7 +26,14 @@ export default function handler(req, res) {
   let responseStarted = false;
 
   try {
-    console.log("Proxying PDF request for:", url);
+    // Enhanced logging for debugging
+    const isIGCSE = url.includes("IGCSE") || req.headers.referer?.includes("IGCSE");
+    console.log("PDF Proxy Request:", {
+      url: url.substring(0, 100) + "...",
+      isIGCSE,
+      referer: req.headers.referer,
+      userAgent: req.headers["user-agent"]
+    });
 
     // Convert Google Drive preview URL to direct download URL
     let downloadUrl = url;
@@ -34,20 +42,33 @@ export default function handler(req, res) {
       if (fileIdMatch) {
         const fileId = fileIdMatch[1];
         downloadUrl = `https://drive.google.com/uc?export=download&id=${fileId}`;
+        console.log(`Converted preview URL to download URL for file ID: ${fileId}`);
       }
     }
 
     // Determine protocol
     const protocol = downloadUrl.startsWith("https:") ? https : http;
 
-    // Make request to fetch the PDF
-    const request = protocol.get(downloadUrl, (response) => {
+    // Make request to fetch the PDF with custom headers
+    const requestOptions = {
+      headers: {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        "Accept": "application/pdf,*/*",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Cache-Control": "no-cache",
+        "Pragma": "no-cache"
+      }
+    };
+
+    const request = protocol.get(downloadUrl, requestOptions, (response) => {
+      console.log(`Initial response status: ${response.statusCode} for ${isIGCSE ? 'IGCSE' : 'IAL'} paper`);
+      
       // Handle redirects
       if ([301, 302, 303, 307, 308].includes(response.statusCode)) {
         const redirectUrl = response.headers.location;
         console.log(
           `Following ${response.statusCode} redirect to:`,
-          redirectUrl
+          redirectUrl?.substring(0, 100) + "..."
         );
 
         const redirectProtocol = redirectUrl.startsWith("https:")
@@ -55,13 +76,21 @@ export default function handler(req, res) {
           : http;
         const redirectRequest = redirectProtocol.get(
           redirectUrl,
+          requestOptions,
           (redirectResponse) => {
             if (responseStarted) return;
             responseStarted = true;
 
-            // Set proper headers for PDF.js
+            console.log(`Redirect response status: ${redirectResponse.statusCode}`);
+
+            // Set proper headers for PDF.js with additional CORS headers
             res.setHeader("Content-Type", "application/pdf");
             res.setHeader("Cache-Control", "public, max-age=3600");
+            res.setHeader("X-Content-Type-Options", "nosniff");
+            
+            // Add content disposition to help with PDF loading
+            const fileName = isIGCSE ? "igcse-paper.pdf" : "ial-paper.pdf";
+            res.setHeader("Content-Disposition", `inline; filename="${fileName}"`);
 
             // Pipe the PDF data to the response
             redirectResponse.pipe(res);
@@ -74,15 +103,15 @@ export default function handler(req, res) {
             responseStarted = true;
             res
               .status(500)
-              .json({ error: "Failed to fetch PDF from redirect" });
+              .json({ error: "Failed to fetch PDF from redirect", details: error.message });
           }
         });
 
-        redirectRequest.setTimeout(25000, () => {
+        redirectRequest.setTimeout(30000, () => {
           console.error("Redirect request timeout for URL:", redirectUrl);
           if (!responseStarted) {
             responseStarted = true;
-            res.status(504).json({ error: "Request timeout" });
+            res.status(504).json({ error: "Request timeout on redirect" });
           }
           redirectRequest.destroy();
         });
@@ -94,12 +123,13 @@ export default function handler(req, res) {
       if (response.statusCode !== 200) {
         console.error(
           `HTTP ${response.statusCode} error for URL:`,
-          downloadUrl
+          downloadUrl.substring(0, 100) + "..."
         );
         if (!responseStarted) {
           responseStarted = true;
           res.status(response.statusCode).json({
             error: `Failed to fetch PDF: HTTP ${response.statusCode}`,
+            isIGCSE
           });
         }
         return;
@@ -108,9 +138,16 @@ export default function handler(req, res) {
       if (responseStarted) return;
       responseStarted = true;
 
+      console.log(`Successfully fetching ${isIGCSE ? 'IGCSE' : 'IAL'} PDF`);
+
       // Set proper headers for PDF.js
       res.setHeader("Content-Type", "application/pdf");
       res.setHeader("Cache-Control", "public, max-age=3600");
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      
+      // Add content disposition
+      const fileName = isIGCSE ? "igcse-paper.pdf" : "ial-paper.pdf";
+      res.setHeader("Content-Disposition", `inline; filename="${fileName}"`);
 
       // Pipe the PDF data to the response
       response.pipe(res);
@@ -120,11 +157,11 @@ export default function handler(req, res) {
       console.error("Error fetching PDF:", error);
       if (!responseStarted) {
         responseStarted = true;
-        res.status(500).json({ error: "Failed to fetch PDF" });
+        res.status(500).json({ error: "Failed to fetch PDF", details: error.message });
       }
     });
 
-    request.setTimeout(25000, () => {
+    request.setTimeout(30000, () => {
       console.error("Request timeout for URL:", url);
       if (!responseStarted) {
         responseStarted = true;
@@ -136,7 +173,7 @@ export default function handler(req, res) {
     console.error("Error in PDF proxy:", error);
     if (!responseStarted) {
       responseStarted = true;
-      res.status(500).json({ error: "Internal server error" });
+      res.status(500).json({ error: "Internal server error", details: error.message });
     }
   }
 }

--- a/src/components/PaperViewer.jsx
+++ b/src/components/PaperViewer.jsx
@@ -337,18 +337,40 @@ export default function PaperViewer({
 
   // Handle iframe load events
   const handleQpLoad = () => {
+    console.log("Question Paper loaded successfully:", {
+      file: selectedFile?.name,
+      path: activePath,
+      isIGCSE: activePath?.includes('IGCSE'),
+      url: selectedFile?.qp
+    });
     setQpLoading(false);
     setQpError(null);
     setQpRetryCount(0);
   };
 
   const handleMsLoad = () => {
+    console.log("Mark Scheme/Document loaded successfully:", {
+      file: selectedFile?.name,
+      path: activePath,
+      isIGCSE: activePath?.includes('IGCSE'),
+      activeTab,
+      url: activeTab === 'ms' ? selectedFile?.ms : 
+           activeTab === 'sp' ? selectedFile?.sp : 
+           selectedFile?.in
+    });
     setMsLoading(false);
     setMsError(null);
     setMsRetryCount(0);
   };
 
   const handleQpError = () => {
+    console.error("Question Paper failed to load:", {
+      file: selectedFile?.name,
+      path: activePath,
+      isIGCSE: activePath?.includes('IGCSE'),
+      url: selectedFile?.qp,
+      retryCount: qpRetryCount
+    });
     setQpLoading(false);
     if (qpRetryCount < 2) {
       setQpError(`Loading Question Paper... Retry ${qpRetryCount + 1}/3`);
@@ -363,6 +385,16 @@ export default function PaperViewer({
   };
 
   const handleMsError = () => {
+    console.error("Mark Scheme/Document failed to load:", {
+      file: selectedFile?.name,
+      path: activePath,
+      isIGCSE: activePath?.includes('IGCSE'),
+      activeTab,
+      url: activeTab === 'ms' ? selectedFile?.ms : 
+           activeTab === 'sp' ? selectedFile?.sp : 
+           selectedFile?.in,
+      retryCount: msRetryCount
+    });
     setMsLoading(false);
     if (msRetryCount < 2) {
       setMsError(
@@ -1156,7 +1188,16 @@ export default function PaperViewer({
               )}
               {selectedFile?.qp && (
                 <iframe
-                  src={getPDFViewerUrl(selectedFile.qp)}
+                  src={(() => {
+                    const url = getPDFViewerUrl(selectedFile.qp);
+                    console.log("Loading QP in side-by-side view:", {
+                      originalUrl: selectedFile.qp,
+                      viewerUrl: url,
+                      isIGCSE: activePath?.includes('IGCSE'),
+                      fileName: selectedFile?.name
+                    });
+                    return url;
+                  })()}
                   className="w-full h-full border-0"
                   title="Question Paper"
                   style={{ backgroundColor: "white" }}
@@ -1194,7 +1235,16 @@ export default function PaperViewer({
               )}
               {activeTab === "ms" && selectedFile?.ms && (
                 <iframe
-                  src={getPDFViewerUrl(selectedFile.ms)}
+                  src={(() => {
+                    const url = getPDFViewerUrl(selectedFile.ms);
+                    console.log("Loading MS in side-by-side view:", {
+                      originalUrl: selectedFile.ms,
+                      viewerUrl: url,
+                      isIGCSE: activePath?.includes('IGCSE'),
+                      fileName: selectedFile?.name
+                    });
+                    return url;
+                  })()}
                   className="w-full h-full border-0"
                   title="Mark Scheme"
                   style={{ backgroundColor: "white" }}
@@ -1204,7 +1254,16 @@ export default function PaperViewer({
               )}
               {activeTab === "sp" && selectedFile?.sp && (
                 <iframe
-                  src={getPDFViewerUrl(selectedFile.sp)}
+                  src={(() => {
+                    const url = getPDFViewerUrl(selectedFile.sp);
+                    console.log("Loading SP in side-by-side view:", {
+                      originalUrl: selectedFile.sp,
+                      viewerUrl: url,
+                      isIGCSE: activePath?.includes('IGCSE'),
+                      fileName: selectedFile?.name
+                    });
+                    return url;
+                  })()}
                   className="w-full h-full border-0"
                   title="Solved Paper"
                   style={{ backgroundColor: "white" }}
@@ -1214,7 +1273,16 @@ export default function PaperViewer({
               )}
               {activeTab === "in" && selectedFile?.in && (
                 <iframe
-                  src={getPDFViewerUrl(selectedFile.in)}
+                  src={(() => {
+                    const url = getPDFViewerUrl(selectedFile.in);
+                    console.log("Loading IN (Booklet) in side-by-side view:", {
+                      originalUrl: selectedFile.in,
+                      viewerUrl: url,
+                      isIGCSE: activePath?.includes('IGCSE'),
+                      fileName: selectedFile?.name
+                    });
+                    return url;
+                  })()}
                   className="w-full h-full border-0"
                   title="Booklet"
                   style={{ backgroundColor: "white" }}
@@ -1243,7 +1311,16 @@ export default function PaperViewer({
             )}
             {activeTab === "qp" && selectedFile?.qp && (
               <iframe
-                src={getPDFViewerUrl(selectedFile.qp)}
+                src={(() => {
+                  const url = getPDFViewerUrl(selectedFile.qp);
+                  console.log("Loading QP in single view:", {
+                    originalUrl: selectedFile.qp,
+                    viewerUrl: url,
+                    isIGCSE: activePath?.includes('IGCSE'),
+                    fileName: selectedFile?.name
+                  });
+                  return url;
+                })()}
                 className="w-full h-full border-0"
                 title="Question Paper"
                 style={{ backgroundColor: "white" }}
@@ -1253,7 +1330,16 @@ export default function PaperViewer({
             )}
             {activeTab === "ms" && selectedFile?.ms && (
               <iframe
-                src={getPDFViewerUrl(selectedFile.ms)}
+                src={(() => {
+                  const url = getPDFViewerUrl(selectedFile.ms);
+                  console.log("Loading MS in single view:", {
+                    originalUrl: selectedFile.ms,
+                    viewerUrl: url,
+                    isIGCSE: activePath?.includes('IGCSE'),
+                    fileName: selectedFile?.name
+                  });
+                  return url;
+                })()}
                 className="w-full h-full border-0"
                 title="Mark Scheme"
                 style={{ backgroundColor: "white" }}
@@ -1263,7 +1349,16 @@ export default function PaperViewer({
             )}
             {activeTab === "sp" && selectedFile?.sp && (
               <iframe
-                src={getPDFViewerUrl(selectedFile.sp)}
+                src={(() => {
+                  const url = getPDFViewerUrl(selectedFile.sp);
+                  console.log("Loading SP in single view:", {
+                    originalUrl: selectedFile.sp,
+                    viewerUrl: url,
+                    isIGCSE: activePath?.includes('IGCSE'),
+                    fileName: selectedFile?.name
+                  });
+                  return url;
+                })()}
                 className="w-full h-full border-0"
                 title="Solved Paper"
                 style={{ backgroundColor: "white" }}
@@ -1273,7 +1368,16 @@ export default function PaperViewer({
             )}
             {activeTab === "in" && selectedFile?.in && (
               <iframe
-                src={getPDFViewerUrl(selectedFile.in)}
+                src={(() => {
+                  const url = getPDFViewerUrl(selectedFile.in);
+                  console.log("Loading IN (Booklet) in single view:", {
+                    originalUrl: selectedFile.in,
+                    viewerUrl: url,
+                    isIGCSE: activePath?.includes('IGCSE'),
+                    fileName: selectedFile?.name
+                  });
+                  return url;
+                })()}
                 className="w-full h-full border-0"
                 title="Booklet"
                 style={{ backgroundColor: "white" }}


### PR DESCRIPTION
Fix PDF.js not loading for IGCSE subjects by enhancing the PDF proxy's robustness and adding detailed logging.

The problem was likely caused by network timeouts or missing HTTP headers when the PDF proxy fetched IGCSE papers from Google Drive. The changes include increasing the proxy timeout, adding necessary request/response headers, and improving error visibility in the `PaperViewer` component to aid future debugging.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d05791e-aae1-4a3b-91ed-305adbf50c4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d05791e-aae1-4a3b-91ed-305adbf50c4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

